### PR TITLE
Remove the bower version notation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "purescript-read",
-  "version": "1.0.0",
   "description": "class utilities for defining readable types (enums) in PureScript",
   "authors": [
     "TruQu <matthias.benkort@truqu.com>"


### PR DESCRIPTION
This causes bower to complain about version mismatches. Alternately, it could be updated to 1.0.2 and released as such.